### PR TITLE
Enable selection of alternate themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # React ❤️ [Utterances](https://github.com/utterance/utterances)
 
-**WithUtterances** is a React Higher-Order-Component for Super LightWeight Comments Widget named [Utterances](https://github.com/utterance/utterances). 
+**WithUtterances** is a React Higher-Order-Component for Super LightWeight Comments Widget named [Utterances](https://github.com/utterance/utterances).
 
-### No need Duplicated DOM Bindings for each react component. 
+### No need Duplicated DOM Bindings for each react component.
 
 #### Just Wrap It!
 
@@ -30,16 +30,28 @@ class PostPage extends React.Component {
     //...
 }
 
-// OR
+// Or
 
 const PostPage = () => {
     //...
 }
 
 export default withUtterances(PostPage, 'YOUR_REPO')
+
+// Or to specify a theme
+
+export default withUtterances(PostPage, 'YOUR_REPO', 'github-dark')
 ```
 
 It uses your pathname as `issue-term`.
+
+#### Supported Themes
+
+By default [Utterances](https://github.com/utterance/utterances) comes with two choices for themes:
+- `github-light` - The normal Github style
+- `github-dark` - A dark mode in the style of Github
+
+More themes can be added [with additional stylesheets](https://github.com/utterance/utterances/blob/master/CONTRIBUTING.md#theme-development).
 
 ### PS. preload and prefetch Applied
 
@@ -49,4 +61,3 @@ It will make your Utterances Widget to load slightly faster. <3
 ### PS. DEMO SITE
 
 [Demo Using withUtterance](https://khw1031.github.io/posts/withUtterances)
-

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,8 @@ import * as React from 'react'
 
 export default function withUtterances<P extends { location: { pathname: string } }>(
   WrappedComponent: React.ComponentClass<P>,
-  repo: string
+  repo: string,
+  theme: string = 'github-light'
 ) {
   return class extends React.Component<P> {
     withUtterancesContainer: React.RefObject<HTMLDivElement> = React.createRef()
@@ -16,6 +17,7 @@ export default function withUtterances<P extends { location: { pathname: string 
       script.src = 'https://utteranc.es/client.js'
       script.async = true
       script.setAttribute('repo', repo)
+      script.setAttribute('theme', theme)
       script.setAttribute('issue-term', this.props.location.pathname || document.location.pathname)
       this.withUtterancesContainer.current.appendChild(script)
     }


### PR DESCRIPTION
Enables the use of custom themes by adding a optional parameter.

By default utterances comes with two choices for themes:
- `github-light` - The normal Github style
- `github-dark` - A dark mode in the style of Github

More themes can be added to utterance by adding additional stylesheets.
See https://github.com/utterance/utterances/blob/master/CONTRIBUTING.md#theme-development

If omitted, the `github-light` theme will be used,
preserving the existing behavior.

Also updates the Readme to explain this parameter.