### PR TITLE
Allow alternate issue naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ export default withUtterances(PostPage, 'YOUR_REPO')
 // Or to specify a theme
 
 export default withUtterances(PostPage, 'YOUR_REPO', 'github-dark')
+
+// Or to specfiy an issue term
+
+export default withUtterances(PostPage, 'YOUR_REPO', 'github-light', 'og:title')
 ```
 
 It uses your pathname as `issue-term`.
@@ -52,6 +56,14 @@ By default [Utterances](https://github.com/utterance/utterances) comes with two 
 - `github-dark` - A dark mode in the style of Github
 
 More themes can be added [with additional stylesheets](https://github.com/utterance/utterances/blob/master/CONTRIBUTING.md#theme-development).
+
+### Supported Issue Terms
+
+- `pathname` - Issue title which contains the path of the current page.
+- `url` - Issue title which contains the URL of the current page.
+- `title` - Issue title which contains the tab title of the current page.
+- `og:title` - Issue title which contains the Open Graph title meta.
+- `<serach term>` - Issue title which contains the given String.
 
 ### PS. preload and prefetch Applied
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,8 @@ import * as React from 'react'
 export default function withUtterances<P extends { location: { pathname: string } }>(
   WrappedComponent: React.ComponentClass<P>,
   repo: string,
-  theme: string = 'github-light'
+  theme: string = 'github-light',
+  term: string = 'pathname'
 ) {
   return class extends React.Component<P> {
     withUtterancesContainer: React.RefObject<HTMLDivElement> = React.createRef()
@@ -18,7 +19,7 @@ export default function withUtterances<P extends { location: { pathname: string 
       script.async = true
       script.setAttribute('repo', repo)
       script.setAttribute('theme', theme)
-      script.setAttribute('issue-term', this.props.location.pathname || document.location.pathname)
+      script.setAttribute('issue-term', term)
       this.withUtterancesContainer.current.appendChild(script)
     }
 


### PR DESCRIPTION
Allows a specific issue term to be specified using an optional parameter.
Defaults to `pathname` to match existing behaviour.

Supported issue terms:
- `pathname` - Issue title which contains the path of the current page.
- `url` - Issue title which contains the URL of the current page.
- `title` - Issue title which contains the tab title of the current page.
- `og:title` - Issue title which contains the Open Graph title meta.
- `<serach term>` - Issue title which contains the given String.